### PR TITLE
Add orchestration layer: DiagnosticReport and Diagnoser

### DIFF
--- a/agentdoctor/__init__.py
+++ b/agentdoctor/__init__.py
@@ -13,13 +13,18 @@ from agentdoctor.models import (
     ToolCall,
     Trace,
 )
-from agentdoctor.detectors import BaseDetector, ToolThrashingDetector
+from agentdoctor.detectors import ALL_DETECTORS, BaseDetector, ToolThrashingDetector
+from agentdoctor.diagnoser import Diagnoser
 from agentdoctor.parsers import BaseParser, JSONParser
+from agentdoctor.report import DiagnosticReport
 from agentdoctor.taxonomy import PATHOLOGY_REGISTRY, Pathology
 
 __all__ = [
+    "ALL_DETECTORS",
     "BaseDetector",
     "BaseParser",
+    "Diagnoser",
+    "DiagnosticReport",
     "ToolThrashingDetector",
     "DetectorResult",
     "JSONParser",

--- a/agentdoctor/detectors/__init__.py
+++ b/agentdoctor/detectors/__init__.py
@@ -3,4 +3,7 @@
 from agentdoctor.detectors.base import BaseDetector
 from agentdoctor.detectors.tool_thrashing import ToolThrashingDetector
 
-__all__ = ["BaseDetector", "ToolThrashingDetector"]
+ALL_DETECTORS: list[type[BaseDetector]] = [ToolThrashingDetector]
+"""Detector classes registered for default use by :class:`Diagnoser`."""
+
+__all__ = ["ALL_DETECTORS", "BaseDetector", "ToolThrashingDetector"]

--- a/agentdoctor/diagnoser.py
+++ b/agentdoctor/diagnoser.py
@@ -1,0 +1,57 @@
+"""Diagnoser orchestrator for AgentDoctor."""
+
+from __future__ import annotations
+
+from agentdoctor.detectors import ALL_DETECTORS, BaseDetector
+from agentdoctor.models import DetectorResult, Severity, Trace
+from agentdoctor.report import DiagnosticReport
+
+
+class Diagnoser:
+    """Primary API entry point that runs detectors against a trace.
+
+    By default, all registered detectors are used. Pass a custom list
+    to run only a subset::
+
+        diagnoser = Diagnoser()                          # all detectors
+        diagnoser = Diagnoser(detectors=[MyDetector()])   # custom subset
+    """
+
+    def __init__(self, detectors: list[BaseDetector] | None = None) -> None:
+        if detectors is not None:
+            self._detectors = list(detectors)
+        else:
+            self._detectors = [cls() for cls in ALL_DETECTORS]
+
+    @property
+    def detectors(self) -> list[BaseDetector]:
+        """The detector instances this diagnoser will run."""
+        return list(self._detectors)
+
+    def diagnose(self, trace: Trace) -> DiagnosticReport:
+        """Run all detectors against *trace* and return a report.
+
+        Each detector runs independently — a single detector raising an
+        exception will not block the others.  Failed detectors produce a
+        result with ``detected=False`` and a description noting the error.
+        """
+        results: list[DetectorResult] = []
+        for detector in self._detectors:
+            try:
+                result = detector.detect(trace)
+                results.append(result)
+            except Exception as exc:
+                results.append(
+                    DetectorResult(
+                        pathology=detector.pathology,
+                        detected=False,
+                        confidence=0.0,
+                        severity=Severity.LOW,
+                        description=f"Detector error: {exc}",
+                    )
+                )
+        return DiagnosticReport(
+            trace_id=trace.trace_id,
+            results=results,
+            metadata=trace.metadata,
+        )

--- a/agentdoctor/report.py
+++ b/agentdoctor/report.py
@@ -1,0 +1,172 @@
+"""Diagnostic report for AgentDoctor analysis results."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from agentdoctor.models import DetectorResult, Severity
+from agentdoctor.taxonomy import PATHOLOGY_REGISTRY
+
+_SEVERITY_ORDER: list[Severity] = [
+    Severity.LOW,
+    Severity.MEDIUM,
+    Severity.HIGH,
+    Severity.CRITICAL,
+]
+
+
+@dataclass
+class DiagnosticReport:
+    """Aggregated results from running detectors against a trace.
+
+    Provides multiple output formats: human-readable summary, JSON for
+    CI/CD integration, Markdown for documentation, and dict for
+    programmatic access.
+    """
+
+    trace_id: str | None
+    results: list[DetectorResult] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def detected_pathologies(self) -> list[DetectorResult]:
+        """Return only results where the pathology was detected."""
+        return [r for r in self.results if r.detected]
+
+    @property
+    def highest_severity(self) -> Severity | None:
+        """Return the most severe level among detected pathologies.
+
+        Returns ``None`` when no pathologies were detected.
+        """
+        detected = self.detected_pathologies
+        if not detected:
+            return None
+        return max(
+            (r.severity for r in detected),
+            key=lambda s: _SEVERITY_ORDER.index(s),
+        )
+
+    def summary(self) -> str:
+        """Return a human-readable summary string."""
+        lines: list[str] = [
+            "AgentDoctor Diagnostic Report",
+            f"Trace: {self.trace_id or 'unknown'}",
+        ]
+
+        severity = self.highest_severity
+        lines.append(f"Overall Severity: {severity.value.upper() if severity else 'NONE'}")
+        lines.append("")
+
+        detected = self.detected_pathologies
+        total = len(self.results)
+        lines.append(f"Detected Pathologies ({len(detected)}/{total}):")
+
+        if detected:
+            for r in detected:
+                info = PATHOLOGY_REGISTRY.get(r.pathology)
+                name = info.name if info else r.pathology.value
+                lines.append(f"  [{r.severity.value.upper():<8s}] {name} — {r.description}")
+        else:
+            lines.append("  No pathologies detected.")
+
+        not_detected = [r for r in self.results if not r.detected]
+        if not_detected:
+            names = []
+            for r in not_detected:
+                info = PATHOLOGY_REGISTRY.get(r.pathology)
+                names.append(info.name if info else r.pathology.value)
+            lines.append("")
+            lines.append(f"No issues found for: {', '.join(names)}")
+
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a fully JSON-serializable dictionary."""
+        return {
+            "trace_id": self.trace_id,
+            "overall_severity": (self.highest_severity.value if self.highest_severity else None),
+            "results": [
+                {
+                    "pathology": r.pathology.value,
+                    "detected": r.detected,
+                    "confidence": r.confidence,
+                    "severity": r.severity.value,
+                    "evidence": r.evidence,
+                    "description": r.description,
+                    "recommendation": r.recommendation,
+                }
+                for r in self.results
+            ],
+            "metadata": self.metadata,
+        }
+
+    def to_json(self, path: str | None = None) -> str:
+        """Serialize the report to a JSON string.
+
+        When *path* is given, the JSON is also written to that file.
+        """
+        data = json.dumps(self.to_dict(), indent=2)
+        if path is not None:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(data)
+        return data
+
+    def to_markdown(self, path: str | None = None) -> str:
+        """Render the report as a Markdown string.
+
+        When *path* is given, the Markdown is also written to that file.
+        """
+        lines: list[str] = [
+            "# AgentDoctor Diagnostic Report",
+            "",
+            f"**Trace:** {self.trace_id or 'unknown'}",
+        ]
+
+        severity = self.highest_severity
+        lines.append(f"**Overall Severity:** {severity.value.upper() if severity else 'NONE'}")
+        lines.append("")
+
+        # Summary table
+        lines.append("## Summary")
+        lines.append("")
+        lines.append("| Pathology | Detected | Severity | Confidence |")
+        lines.append("|-----------|----------|----------|------------|")
+        for r in self.results:
+            info = PATHOLOGY_REGISTRY.get(r.pathology)
+            name = info.name if info else r.pathology.value
+            detected_str = "Yes" if r.detected else "No"
+            sev_str = r.severity.value.upper() if r.detected else "-"
+            conf_str = f"{r.confidence:.0%}"
+            lines.append(f"| {name} | {detected_str} | {sev_str} | {conf_str} |")
+
+        # Details for detected pathologies
+        detected = self.detected_pathologies
+        if detected:
+            lines.append("")
+            lines.append("## Detected Pathologies")
+            for r in detected:
+                info = PATHOLOGY_REGISTRY.get(r.pathology)
+                name = info.name if info else r.pathology.value
+                lines.append("")
+                lines.append(f"### {name}")
+                lines.append("")
+                lines.append(f"**Severity:** {r.severity.value.upper()}")
+                lines.append(f"**Confidence:** {r.confidence:.0%}")
+                if r.description:
+                    lines.append(f"**Description:** {r.description}")
+                if r.recommendation:
+                    lines.append(f"**Recommendation:** {r.recommendation}")
+                if r.evidence:
+                    lines.append("")
+                    lines.append("**Evidence:**")
+                    for e in r.evidence:
+                        lines.append(f"- {e}")
+
+        md = "\n".join(lines) + "\n"
+        if path is not None:
+            with open(path, "w", encoding="utf-8") as f:
+                f.write(md)
+        return md

--- a/tests/test_diagnoser.py
+++ b/tests/test_diagnoser.py
@@ -1,0 +1,212 @@
+"""Tests for the Diagnoser orchestrator."""
+
+from __future__ import annotations
+
+from agentdoctor.detectors import ALL_DETECTORS
+from agentdoctor.detectors.base import BaseDetector
+from agentdoctor.diagnoser import Diagnoser
+from agentdoctor.models import DetectorResult, Severity, Trace
+from agentdoctor.parsers import JSONParser
+from agentdoctor.report import DiagnosticReport
+from agentdoctor.taxonomy import Pathology
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysDetects(BaseDetector):
+    """Stub detector that always reports a detection."""
+
+    @property
+    def pathology(self) -> Pathology:
+        return Pathology.CONTEXT_EROSION
+
+    def detect(self, trace: Trace) -> DetectorResult:
+        return DetectorResult(
+            pathology=self.pathology,
+            detected=True,
+            confidence=0.9,
+            severity=Severity.HIGH,
+            description="Stub detection",
+        )
+
+
+class _NeverDetects(BaseDetector):
+    """Stub detector that never reports a detection."""
+
+    @property
+    def pathology(self) -> Pathology:
+        return Pathology.INSTRUCTION_DRIFT
+
+    def detect(self, trace: Trace) -> DetectorResult:
+        return DetectorResult(
+            pathology=self.pathology,
+            detected=False,
+            confidence=0.8,
+        )
+
+
+class _ExplodingDetector(BaseDetector):
+    """Stub detector that raises an exception."""
+
+    @property
+    def pathology(self) -> Pathology:
+        return Pathology.RECOVERY_BLINDNESS
+
+    def detect(self, trace: Trace) -> DetectorResult:
+        raise RuntimeError("boom")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultConstructor:
+    def test_creates_all_registered_detectors(self):
+        diagnoser = Diagnoser()
+        assert len(diagnoser.detectors) == len(ALL_DETECTORS)
+
+    def test_detector_types_match_registry(self):
+        diagnoser = Diagnoser()
+        actual_types = {type(d) for d in diagnoser.detectors}
+        expected_types = set(ALL_DETECTORS)
+        assert actual_types == expected_types
+
+
+class TestCustomConstructor:
+    def test_accepts_custom_detectors(self):
+        custom = [_AlwaysDetects(), _NeverDetects()]
+        diagnoser = Diagnoser(detectors=custom)
+        assert len(diagnoser.detectors) == 2
+
+    def test_empty_list(self):
+        diagnoser = Diagnoser(detectors=[])
+        assert diagnoser.detectors == []
+
+
+class TestDiagnose:
+    def test_returns_diagnostic_report(self):
+        diagnoser = Diagnoser(detectors=[_NeverDetects()])
+        trace = Trace(trace_id="test-1")
+        report = diagnoser.diagnose(trace)
+        assert isinstance(report, DiagnosticReport)
+
+    def test_report_contains_correct_result_count(self):
+        diagnoser = Diagnoser(detectors=[_AlwaysDetects(), _NeverDetects()])
+        report = diagnoser.diagnose(Trace(trace_id="test-2"))
+        assert len(report.results) == 2
+
+    def test_report_trace_id_matches(self):
+        diagnoser = Diagnoser(detectors=[_NeverDetects()])
+        report = diagnoser.diagnose(Trace(trace_id="abc-123"))
+        assert report.trace_id == "abc-123"
+
+    def test_report_metadata_preserved(self):
+        diagnoser = Diagnoser(detectors=[_NeverDetects()])
+        trace = Trace(trace_id="t", metadata={"env": "test"})
+        report = diagnoser.diagnose(trace)
+        assert report.metadata == {"env": "test"}
+
+    def test_healthy_trace_no_detections(self):
+        diagnoser = Diagnoser(detectors=[_NeverDetects()])
+        report = diagnoser.diagnose(Trace(trace_id="healthy"))
+        assert report.detected_pathologies == []
+
+    def test_pathology_detected(self):
+        diagnoser = Diagnoser(detectors=[_AlwaysDetects()])
+        report = diagnoser.diagnose(Trace(trace_id="sick"))
+        detected = report.detected_pathologies
+        assert len(detected) == 1
+        assert detected[0].pathology is Pathology.CONTEXT_EROSION
+
+    def test_mixed_results(self):
+        diagnoser = Diagnoser(detectors=[_AlwaysDetects(), _NeverDetects()])
+        report = diagnoser.diagnose(Trace(trace_id="mixed"))
+        assert len(report.detected_pathologies) == 1
+        assert len(report.results) == 2
+
+    def test_empty_trace(self):
+        diagnoser = Diagnoser(detectors=[_NeverDetects()])
+        report = diagnoser.diagnose(Trace())
+        assert isinstance(report, DiagnosticReport)
+        assert report.trace_id is None
+
+    def test_no_detectors_empty_results(self):
+        diagnoser = Diagnoser(detectors=[])
+        report = diagnoser.diagnose(Trace(trace_id="empty"))
+        assert report.results == []
+        assert report.detected_pathologies == []
+
+
+class TestDetectorIsolation:
+    def test_one_failure_does_not_block_others(self):
+        diagnoser = Diagnoser(detectors=[_AlwaysDetects(), _ExplodingDetector(), _NeverDetects()])
+        report = diagnoser.diagnose(Trace(trace_id="isolation"))
+        # All 3 detectors should produce results
+        assert len(report.results) == 3
+        # The exploding one should produce a non-detected result
+        exploded = [r for r in report.results if r.pathology is Pathology.RECOVERY_BLINDNESS]
+        assert len(exploded) == 1
+        assert exploded[0].detected is False
+        assert "boom" in exploded[0].description
+
+    def test_failed_detector_does_not_affect_detected(self):
+        diagnoser = Diagnoser(detectors=[_AlwaysDetects(), _ExplodingDetector()])
+        report = diagnoser.diagnose(Trace(trace_id="fail"))
+        detected = report.detected_pathologies
+        assert len(detected) == 1
+        assert detected[0].pathology is Pathology.CONTEXT_EROSION
+
+
+class TestEndToEnd:
+    def test_with_json_parser_healthy(self):
+        """Parse a healthy fixture and run default detectors."""
+        parser = JSONParser()
+        trace = parser.parse("tests/fixtures/traces/healthy_trace.json")
+        diagnoser = Diagnoser()
+        report = diagnoser.diagnose(trace)
+        assert isinstance(report, DiagnosticReport)
+        assert report.trace_id == "healthy-001"
+        # Healthy trace should have no tool thrashing
+        for r in report.results:
+            if r.pathology is Pathology.TOOL_THRASHING:
+                assert r.detected is False
+
+    def test_with_json_parser_thrashing(self):
+        """Parse a thrashing fixture and verify detection."""
+        parser = JSONParser()
+        trace = parser.parse("tests/fixtures/traces/thrashing_trace.json")
+        diagnoser = Diagnoser()
+        report = diagnoser.diagnose(trace)
+        assert isinstance(report, DiagnosticReport)
+        assert report.trace_id == "thrashing-001"
+        # Thrashing trace should be detected
+        thrashing = [r for r in report.results if r.pathology is Pathology.TOOL_THRASHING]
+        assert len(thrashing) == 1
+        assert thrashing[0].detected is True
+
+    def test_full_pipeline_summary(self):
+        """Parse → diagnose → summary round-trip."""
+        parser = JSONParser()
+        trace = parser.parse("tests/fixtures/traces/thrashing_trace.json")
+        report = Diagnoser().diagnose(trace)
+        summary = report.summary()
+        assert "thrashing-001" in summary
+        assert "Tool Thrashing" in summary
+
+
+class TestImports:
+    def test_import_from_top_level(self):
+        from agentdoctor import Diagnoser, DiagnosticReport
+
+        assert Diagnoser is not None
+        assert DiagnosticReport is not None
+
+    def test_all_detectors_exported(self):
+        from agentdoctor import ALL_DETECTORS
+
+        assert isinstance(ALL_DETECTORS, list)
+        assert len(ALL_DETECTORS) >= 1

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,335 @@
+"""Tests for the DiagnosticReport class."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+
+from agentdoctor.models import DetectorResult, Severity
+from agentdoctor.report import DiagnosticReport
+from agentdoctor.taxonomy import Pathology
+
+
+def _make_result(
+    pathology: Pathology,
+    detected: bool,
+    confidence: float = 0.5,
+    severity: Severity = Severity.LOW,
+    description: str = "",
+    recommendation: str = "",
+    evidence: list[str] | None = None,
+) -> DetectorResult:
+    return DetectorResult(
+        pathology=pathology,
+        detected=detected,
+        confidence=confidence,
+        severity=severity,
+        description=description,
+        recommendation=recommendation,
+        evidence=evidence or [],
+    )
+
+
+class TestDetectedPathologies:
+    def test_filters_only_detected(self):
+        report = DiagnosticReport(
+            trace_id="t-1",
+            results=[
+                _make_result(Pathology.TOOL_THRASHING, detected=True),
+                _make_result(Pathology.CONTEXT_EROSION, detected=False),
+                _make_result(Pathology.GOAL_HIJACKING, detected=True),
+            ],
+        )
+        detected = report.detected_pathologies
+        assert len(detected) == 2
+        pathologies = {r.pathology for r in detected}
+        assert pathologies == {Pathology.TOOL_THRASHING, Pathology.GOAL_HIJACKING}
+
+    def test_empty_when_none_detected(self):
+        report = DiagnosticReport(
+            trace_id="t-2",
+            results=[
+                _make_result(Pathology.TOOL_THRASHING, detected=False),
+                _make_result(Pathology.CONTEXT_EROSION, detected=False),
+            ],
+        )
+        assert report.detected_pathologies == []
+
+    def test_empty_results(self):
+        report = DiagnosticReport(trace_id="t-3", results=[])
+        assert report.detected_pathologies == []
+
+
+class TestHighestSeverity:
+    def test_returns_highest(self):
+        report = DiagnosticReport(
+            trace_id="t-4",
+            results=[
+                _make_result(Pathology.TOOL_THRASHING, detected=True, severity=Severity.LOW),
+                _make_result(Pathology.GOAL_HIJACKING, detected=True, severity=Severity.CRITICAL),
+                _make_result(Pathology.CONTEXT_EROSION, detected=True, severity=Severity.MEDIUM),
+            ],
+        )
+        assert report.highest_severity is Severity.CRITICAL
+
+    def test_returns_none_when_nothing_detected(self):
+        report = DiagnosticReport(
+            trace_id="t-5",
+            results=[_make_result(Pathology.TOOL_THRASHING, detected=False)],
+        )
+        assert report.highest_severity is None
+
+    def test_returns_none_for_empty_results(self):
+        report = DiagnosticReport(trace_id="t-6", results=[])
+        assert report.highest_severity is None
+
+    def test_single_detected(self):
+        report = DiagnosticReport(
+            trace_id="t-7",
+            results=[
+                _make_result(Pathology.TOOL_THRASHING, detected=True, severity=Severity.HIGH),
+            ],
+        )
+        assert report.highest_severity is Severity.HIGH
+
+    def test_severity_ordering(self):
+        """Verify CRITICAL > HIGH > MEDIUM > LOW."""
+        for higher, lower in [
+            (Severity.CRITICAL, Severity.HIGH),
+            (Severity.HIGH, Severity.MEDIUM),
+            (Severity.MEDIUM, Severity.LOW),
+        ]:
+            report = DiagnosticReport(
+                trace_id="t-ord",
+                results=[
+                    _make_result(Pathology.TOOL_THRASHING, detected=True, severity=lower),
+                    _make_result(Pathology.GOAL_HIJACKING, detected=True, severity=higher),
+                ],
+            )
+            assert report.highest_severity is higher
+
+
+class TestSummary:
+    def test_contains_trace_id(self):
+        report = DiagnosticReport(trace_id="my-trace", results=[])
+        assert "my-trace" in report.summary()
+
+    def test_unknown_trace_id_when_none(self):
+        report = DiagnosticReport(trace_id=None, results=[])
+        assert "unknown" in report.summary()
+
+    def test_contains_detected_count(self):
+        report = DiagnosticReport(
+            trace_id="t-s",
+            results=[
+                _make_result(
+                    Pathology.TOOL_THRASHING,
+                    detected=True,
+                    severity=Severity.HIGH,
+                    description="5 repeated calls",
+                ),
+                _make_result(Pathology.CONTEXT_EROSION, detected=False),
+            ],
+        )
+        s = report.summary()
+        assert "1/2" in s
+        assert "Tool Thrashing" in s
+        assert "Context Erosion" in s
+
+    def test_clean_report_no_detections(self):
+        report = DiagnosticReport(
+            trace_id="clean",
+            results=[_make_result(Pathology.TOOL_THRASHING, detected=False)],
+        )
+        s = report.summary()
+        assert "0/1" in s
+        assert "No pathologies detected" in s
+
+    def test_overall_severity_in_summary(self):
+        report = DiagnosticReport(
+            trace_id="sev",
+            results=[
+                _make_result(Pathology.TOOL_THRASHING, detected=True, severity=Severity.HIGH),
+            ],
+        )
+        assert "HIGH" in report.summary()
+
+
+class TestToDict:
+    def test_produces_serializable_dict(self):
+        report = DiagnosticReport(
+            trace_id="d-1",
+            results=[
+                _make_result(
+                    Pathology.TOOL_THRASHING,
+                    detected=True,
+                    confidence=0.85,
+                    severity=Severity.HIGH,
+                    description="test desc",
+                    recommendation="test rec",
+                    evidence=["evidence line 1"],
+                ),
+            ],
+            metadata={"source": "test"},
+        )
+        d = report.to_dict()
+        # Should be JSON-serializable (no enums left)
+        json_str = json.dumps(d)
+        loaded = json.loads(json_str)
+        assert loaded["trace_id"] == "d-1"
+        assert loaded["overall_severity"] == "high"
+        assert len(loaded["results"]) == 1
+        r = loaded["results"][0]
+        assert r["pathology"] == "tool_thrashing"
+        assert r["detected"] is True
+        assert r["confidence"] == 0.85
+        assert r["severity"] == "high"
+        assert r["evidence"] == ["evidence line 1"]
+        assert r["description"] == "test desc"
+        assert r["recommendation"] == "test rec"
+        assert loaded["metadata"] == {"source": "test"}
+
+    def test_overall_severity_none_when_clean(self):
+        report = DiagnosticReport(
+            trace_id="d-2",
+            results=[_make_result(Pathology.TOOL_THRASHING, detected=False)],
+        )
+        assert report.to_dict()["overall_severity"] is None
+
+    def test_empty_results(self):
+        report = DiagnosticReport(trace_id="d-3", results=[])
+        d = report.to_dict()
+        assert d["results"] == []
+        assert d["overall_severity"] is None
+
+
+class TestToJson:
+    def test_returns_valid_json_string(self):
+        report = DiagnosticReport(
+            trace_id="j-1",
+            results=[_make_result(Pathology.TOOL_THRASHING, detected=True)],
+        )
+        json_str = report.to_json()
+        loaded = json.loads(json_str)
+        assert loaded["trace_id"] == "j-1"
+
+    def test_writes_file(self):
+        report = DiagnosticReport(
+            trace_id="j-2",
+            results=[_make_result(Pathology.TOOL_THRASHING, detected=True)],
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            path = f.name
+        try:
+            report.to_json(path)
+            with open(path, encoding="utf-8") as f:
+                loaded = json.load(f)
+            assert loaded["trace_id"] == "j-2"
+        finally:
+            os.unlink(path)
+
+    def test_json_is_indented(self):
+        report = DiagnosticReport(trace_id="j-3", results=[])
+        json_str = report.to_json()
+        assert "\n" in json_str  # indent=2 produces newlines
+
+
+class TestToMarkdown:
+    def test_contains_header(self):
+        report = DiagnosticReport(
+            trace_id="m-1",
+            results=[_make_result(Pathology.TOOL_THRASHING, detected=True)],
+        )
+        md = report.to_markdown()
+        assert "# AgentDoctor Diagnostic Report" in md
+
+    def test_contains_summary_table(self):
+        report = DiagnosticReport(
+            trace_id="m-2",
+            results=[
+                _make_result(
+                    Pathology.TOOL_THRASHING,
+                    detected=True,
+                    severity=Severity.HIGH,
+                    confidence=0.9,
+                ),
+                _make_result(Pathology.CONTEXT_EROSION, detected=False, confidence=0.8),
+            ],
+        )
+        md = report.to_markdown()
+        assert "| Pathology |" in md
+        assert "Tool Thrashing" in md
+        assert "Context Erosion" in md
+        assert "90%" in md
+        assert "HIGH" in md
+
+    def test_detected_pathologies_section(self):
+        report = DiagnosticReport(
+            trace_id="m-3",
+            results=[
+                _make_result(
+                    Pathology.TOOL_THRASHING,
+                    detected=True,
+                    description="test description",
+                    recommendation="try caching",
+                    evidence=["evidence item 1"],
+                ),
+            ],
+        )
+        md = report.to_markdown()
+        assert "## Detected Pathologies" in md
+        assert "### Tool Thrashing" in md
+        assert "test description" in md
+        assert "try caching" in md
+        assert "- evidence item 1" in md
+
+    def test_no_detected_section_when_clean(self):
+        report = DiagnosticReport(
+            trace_id="m-4",
+            results=[_make_result(Pathology.TOOL_THRASHING, detected=False)],
+        )
+        md = report.to_markdown()
+        assert "## Detected Pathologies" not in md
+
+    def test_writes_file(self):
+        report = DiagnosticReport(
+            trace_id="m-5",
+            results=[_make_result(Pathology.TOOL_THRASHING, detected=True)],
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            path = f.name
+        try:
+            report.to_markdown(path)
+            with open(path, encoding="utf-8") as f:
+                content = f.read()
+            assert "# AgentDoctor Diagnostic Report" in content
+        finally:
+            os.unlink(path)
+
+
+class TestFullReport:
+    def test_all_pathologies_detected(self):
+        results = [_make_result(p, detected=True, severity=Severity.HIGH) for p in Pathology]
+        report = DiagnosticReport(trace_id="full", results=results)
+        assert len(report.detected_pathologies) == 7
+        assert report.highest_severity is Severity.HIGH
+        s = report.summary()
+        assert "7/7" in s
+
+    def test_round_trip_json(self):
+        """to_dict() → json.dumps → json.loads produces identical data."""
+        results = [
+            _make_result(
+                Pathology.TOOL_THRASHING,
+                detected=True,
+                confidence=0.95,
+                severity=Severity.CRITICAL,
+                evidence=["e1", "e2"],
+            ),
+            _make_result(Pathology.CONTEXT_EROSION, detected=False, confidence=0.7),
+        ]
+        report = DiagnosticReport(trace_id="rt", results=results, metadata={"k": "v"})
+        d1 = report.to_dict()
+        d2 = json.loads(json.dumps(d1))
+        assert d1 == d2


### PR DESCRIPTION
## Summary
- **DiagnosticReport** (`agentdoctor/report.py`): Aggregates detector results with `detected_pathologies`, `highest_severity`, `summary()`, `to_dict()`, `to_json()`, and `to_markdown()` output methods
- **Diagnoser** (`agentdoctor/diagnoser.py`): Orchestrator that runs all registered detectors against a trace with per-detector error isolation — one detector crashing doesn't block the rest
- **ALL_DETECTORS** registry in `detectors/__init__.py` for default detector set
- 46 new tests (26 report + 20 diagnoser) covering true positives, true negatives, edge cases, error isolation, and full end-to-end pipeline tests

Closes #15, closes #13

## Context
These two components complete the user-facing API pipeline:
```
Parser → Trace → Diagnoser → [Detectors] → DiagnosticReport
```

Usage:
```python
from agentdoctor import Diagnoser, JSONParser

trace = JSONParser().parse("trace.json")
report = Diagnoser().diagnose(trace)
print(report.summary())
report.to_json("output.json")
```

## Test plan
- [x] 222 tests pass (`pytest tests/ -v`)
- [x] Lint clean (`ruff check` + `ruff format --check`)
- [x] End-to-end tests verify parse → diagnose → summary pipeline
- [x] Detector isolation tested: exploding detector doesn't crash others
- [x] All output formats tested: summary, to_dict, to_json (file write + round-trip), to_markdown (file write)
- [x] Edge cases: empty trace, no detectors, all 7 pathologies detected, clean report

🤖 Generated with [Claude Code](https://claude.com/claude-code)